### PR TITLE
Fix minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8.2)
 project(epigraph)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
CMake C++17 support is only available starting with version 3.8.2.

Using CMake 3.5 as currently required creates compilation errors